### PR TITLE
Add project management README in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# OctoAcme Project Management Documentation
+
+Welcome to the OctoAcme Project Management Docs! This README serves as the entry point to our structured project management knowledge and process documentation.
+
+## Overview of OctoAcme Project Management Processes
+
+- **Customer-first and outcome driven:** Every project starts with a clear problem statement, stakeholder alignment, measurable goals, and a success plan.
+- **Lifecycle stages:** Initiation (one-pager + stakeholder alignment), planning (prioritized/estimated backlog, risk register), structured execution (stand‑ups, demos, QA, blocker escalation), and retrospective/continuous improvement cycles.
+- **Clear responsibilities:** Roles for Product, Project, Development, and Stakeholders are documented. Ownership, risk escalation, and release criteria are defined.
+- **Standard templates:** One‑pager, planning backlog, risk register, retrospective, and release notes templates help ensure consistency.
+- **Versioned and accessible knowledge:** All documentation is available to team members to increase repeatability and reduce onboarding time.
+
+## Quick Links to Docs
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](octoacme-roles-and-personas.md)
+
+> _This README was added to improve discoverability of existing process knowledge, provide a consistent onboarding entry point, and help team members quickly access all relevant process documentation._


### PR DESCRIPTION
This PR adds a top-level README in the docs/ folder containing an overview of OctoAcme's project management processes and quick links to all existing docs.\n\nCloses #2